### PR TITLE
Fix duplicate router in backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,4 +19,3 @@ from routers.retrieval import router as retrieval_router
 app = FastAPI()
 app.include_router(retrieval_router, prefix="/retrieval", tags=["retrieval"])
 app.include_router(index_router, prefix="/index", tags=["index"])
-app.include_router(index_router, prefix="/index", tags=["index"])


### PR DESCRIPTION
## Summary
- avoid registering index router twice in backend

## Testing
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_683f88b00954832a81c942b6f904593a